### PR TITLE
Return extended information by author from articles

### DIFF
--- a/src/apps/blog/serializers.py
+++ b/src/apps/blog/serializers.py
@@ -1,7 +1,20 @@
 from rest_framework import serializers
 
-from src.apps.blog.models import Tag
+from src.apps.account.models import User
 from src.apps.blog.models import Article
+from src.apps.blog.models import Tag
+
+
+class UserSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = User
+        fields = (
+            "id",
+            "username",
+            "avatar",
+            "first_name",
+            "last_name",
+        )
 
 
 class TagsForArticleSerializer(serializers.ModelSerializer):
@@ -16,6 +29,7 @@ class TagsForArticleSerializer(serializers.ModelSerializer):
 class ArticleListSerializer(serializers.ModelSerializer):
     tags = TagsForArticleSerializer(many=True, read_only=True)
     image_preview = serializers.CharField(source="get_image")
+    author = UserSerializer(read_only=True)
 
     class Meta:
         model = Article
@@ -34,6 +48,7 @@ class ArticleListSerializer(serializers.ModelSerializer):
 class ArticleRetrieveSerializer(serializers.ModelSerializer):
     tags = TagsForArticleSerializer(many=True, read_only=True)
     image_preview = serializers.CharField(source="get_image")
+    author = UserSerializer(read_only=True)
 
     class Meta:
         model = Article


### PR DESCRIPTION
When querying articles, we now get extended information about the author:
``` json
{
  "title": "О нитках",
  "slug": "-2",
  "content": "<p>Нитки красивые</p>",
  "is_active": true,
  "author": {
    "id": 1,
    "username": "admin",
    "avatar": "http://127.0.0.1:8000/media/%D0%BC%D0%B0%D0%BB%D1%8C%D1%87%D0%B8%D0%BA-%D0%B8-%D0%B3%D1%83%D1%81%D0%B5%D0%BD%D0%B8%D1%86%D0%B0-%D0%BE%D0%B1%D0%BB%D0%BE%D0%B6%D0%BA%D0%B0_fgd53kS.png",
    "first_name": "Админ",
    "last_name": "Админыч"
  },
  "tags": [
    {
      "title": "nity",
      "slug": "nity"
    }
  ],
  "image_preview": null,
  "image_alt": "",
  "title_seo": "О нитках",
  "meta_keywords": "нитки",
  "meta_description": "нитки",
  "created_at": "31-03-2023 09:27",
  "updated_at": "31-03-2023 09:27"
}
```